### PR TITLE
update leader role and logic for sending leader heartbeat

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -110,11 +110,11 @@ func elect(
 		
 		select {
 		case <-winnerChannel: // got enough votes
-			for serverIndex, leaderCommunicationChannel := range leaderCommunicationChannels {
-				leaderCommunicationChannel := leaderCommunicationChannel
-				go func () {
-					leaderCommunicationChannel <- LogEntry{serverIndex, state.CurrentTerm, KeyValue{"assert", "dominance"}}
-				}()
+			for serverIndex, leaderCommunicationChannel := range *leaderCommunicationChannels {
+				serverStateLock.Lock()
+				state.Role = LeaderRole
+				serverStateLock.Unlock()
+				leaderCommunicationChannel <- LogEntry{serverIndex, state.CurrentTerm, KeyValue{"assert", "dominance"}}
 			}
 		}
 	// CurrentTerm is used as a flag to identify if a server has voted.

--- a/cluster.go
+++ b/cluster.go
@@ -92,8 +92,10 @@ func startServer(
 		done <- true
 	}()
 
-	/* On Win Handler
-	 *
+	/* On Win Handler. Responsibilities includes
+	 * - updating role of server to leader
+	 * - running heartbeat thread
+	 * - managing client requests (in progress)
 	 */
 	go func(){
 		select {
@@ -101,7 +103,8 @@ func startServer(
 			serverStateLock.Lock()
 			state.Role = LeaderRole
 			serverStateLock.Unlock()
-			runHeartbeatThread(&state, leaderCommunicationChannels)
+			go runHeartbeatThread(&state, leaderCommunicationChannels)
+			go readAndDistributeClientRequests()
 		}
 	}()
 }
@@ -115,6 +118,8 @@ func runHeartbeatThread(state * ServerState, leaderCommunicationChannels *[Clust
 		time.Sleep(HeartBeatDelay * time.Millisecond)
 	}
 }
+
+func readAndDistributeClientRequests(){} //dummy function in charge of distributed append logs to followers
 
 func printMessageFromLeader(id int, logEntry LogEntry){
 	if logEntry.Content.Key == "" &&

--- a/cluster.go
+++ b/cluster.go
@@ -73,7 +73,7 @@ func startServer(
 				isElection = false
 			}
 			timeSinceLastUpdate = time.Now()
-			fmt.Print("New log entry received from leader:", newLogEntry, "\n")
+			fmt.Print(state.ServerId, ": received log entry received from leader -> ", newLogEntry, "\n")
 			//process log entry here
 		}
 		done <- true
@@ -107,8 +107,7 @@ func elect(
 		//count votes
 		winnerChannel := make(chan bool)
 		go requestVotes(state, voteChannels, winnerChannel)
-		
-		
+
 		select {
 		case <-winnerChannel: // got enough votes
 			for serverIndex, leaderCommunicationChannel := range *leaderCommunicationChannels {
@@ -156,6 +155,6 @@ func requestVotes(state * ServerState, voteChannels *[ClusterSize]chan Vote, win
 		fmt.Println("Server ", state.ServerId, " is the leader!")
 		winnerChannel <- true
 	} else {
-		fmt.Println("Server ", state.ServerId, " lost election.")
+		fmt.Println("Server ", state.ServerId, " lost the election.")
 	}
 }

--- a/cluster.go
+++ b/cluster.go
@@ -108,13 +108,14 @@ func elect(
 		winnerChannel := make(chan bool)
 		go requestVotes(state, voteChannels, winnerChannel)
 		
+		
 		select {
 		case <-winnerChannel: // got enough votes
 			for serverIndex, leaderCommunicationChannel := range *leaderCommunicationChannels {
 				serverStateLock.Lock()
 				state.Role = LeaderRole
 				serverStateLock.Unlock()
-				leaderCommunicationChannel <- LogEntry{serverIndex, state.CurrentTerm, KeyValue{"assert", "dominance"}}
+				leaderCommunicationChannel <- LogEntry{serverIndex, state.CurrentTerm, KeyValue{"", ""}}
 			}
 		}
 	// CurrentTerm is used as a flag to identify if a server has voted.

--- a/raft.go
+++ b/raft.go
@@ -7,6 +7,7 @@ func main() {
 	//    - might need a reject channel for when the cluster fails to 
 	//      store the pair (meaning it does an election and starts a 
 	//      new term) so the client needs to resend it
+	fmt.Print("Creating cluster...\n")
 
 	// 2. Spawn cluster
 	done := make(chan bool)


### PR DESCRIPTION
- When enough votes have been reached, a message is sent through onWinChannel that travels to `startServer`
- onWinChannel handler in `startServer` reads message and updates role to leader
- afterwards, onWinChannel handler in `startServer` starts sending heartbeats
