### PR TITLE
Adding missing state properties necessary for keeping track of lag in log processing

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -27,7 +27,7 @@ func initCluster(done chan bool, persister Persister) {
 	// Spawn 8 nodes (all followers to start)
 	for i := 0; i < ClusterSize; i++ {
 		// initialize state as followers
-		state := ServerState{i, 0, -1, previousLogEntries, FollowerRole}
+		state := ServerState{i, 0, -1, previousLogEntries, FollowerRole, 0,0}
 
 		voteChannels[i] = make(chan Vote)
 		leaderCommunicationChannel[i] = make(chan LogEntry)


### PR DESCRIPTION
Basically took the summary from Figure 2 in the extended paper and wrote down all the properties they have listed there. This is assuming we will need the same attributes, but this may not be the case -- comment on anything you feel we might not need