### PR TITLE
Start election at cluster initialization

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
 	"sync"
 )
 import "time"
@@ -48,7 +47,7 @@ func startServer(
 	appendEntriesCom *[ClusterSize]AppendEntriesCom,
 	clientCommunicationChannel chan KeyValue) {
 
-	isElection := false
+	isElection := true
 	electionThreadSleepTime := time.Millisecond * 1000
 	timeSinceLastUpdate := time.Now() //update includes election or message from leader
 	serverStateLock := new(sync.Mutex)
@@ -56,38 +55,33 @@ func startServer(
 
 	go runElectionTimeoutThread(&timeSinceLastUpdate, &isElection, state, voteChannels, &onWinChannel, electionThreadSleepTime)
 	go startLeaderListener(appendEntriesCom, state, &timeSinceLastUpdate, &isElection, serverStateLock)
-	go onWinChannelListener(state, &onWinChannel, serverStateLock, appendEntriesCom, &clientCommunicationChannel)
+	go onWinChannelListener(state, &onWinChannel, serverStateLock, appendEntriesCom, &clientCommunicationChannel) //in leader.go
 }
 
-/* On Win Handler. Responsibilities includes
- * - updating role of server to leader
- * - running heartbeat thread
- * - managing client requests (in progress)
+/* Election Timer: Checks if timeout is surpassed and starts election. Timeout is reached when:
+ * 1. no message from leader or
+ * 2. when election took too long (e.g. due to tie / no leader elected)
  */
-func onWinChannelListener(
-	state *ServerState,
+func runElectionTimeoutThread(
+	timeSinceLastUpdate * time.Time,
+	isElection * bool,
+	state * ServerState,
+	voteChannels *[8]chan Vote,
 	onWinChannel * chan bool,
-	serverStateLock *sync.Mutex,
-	appendEntriesCom *[8]AppendEntriesCom,
-	clientCommunicationChannel * chan KeyValue) {
-	//TODO: What if received message from new leader before onWinChannel gets to hear about it?
+	electionThreadSleepTime time.Duration,
+) {
 	for {
-		select {
-		case <-* onWinChannel: // got enough votes
-			serverStateLock.Lock()
-			state.Role = LeaderRole
-			serverStateLock.Unlock()
-
-			// initialize leader state
-			var leaderState [ClusterSize]LeaderState
-			for i := 0; i < ClusterSize; i++ {
-				// Note that logentries are indexed from 1
-				leaderState[i] = LeaderState{len(state.Log) + 1, 0}
-			}
-
-			go runHeartbeatThread(state, appendEntriesCom) // Implements L1.
-			go readAndDistributeClientRequests(state, &leaderState, appendEntriesCom, clientCommunicationChannel)
+		timeElapsed := time.Now().Sub(*timeSinceLastUpdate)
+		if timeElapsed.Milliseconds() > ElectionTimeOut { //implements C4.
+			*isElection = true
 		}
+
+		if *isElection {
+			*timeSinceLastUpdate = time.Now()
+			go elect(state, voteChannels, *onWinChannel)
+		}
+
+		time.Sleep(electionThreadSleepTime)
 	}
 }
 
@@ -119,33 +113,6 @@ func startLeaderListener(
 				}
 			}
 		}
-	}
-}
-
-/* Election Timer: Checks if timeout is surpassed and starts election. Timeout is reached when:
- * 1. no message from leader or
- * 2. when election took too long (e.g. due to tie / no leader elected)
- */
-func runElectionTimeoutThread(
-	timeSinceLastUpdate * time.Time,
-	isElection * bool,
-	state * ServerState,
-	voteChannels *[8]chan Vote,
-	onWinChannel * chan bool,
-	electionThreadSleepTime time.Duration,
-	) {
-	for {
-		timeElapsed := time.Now().Sub(*timeSinceLastUpdate)
-		if timeElapsed.Milliseconds() > ElectionTimeOut { //implements C4.
-			*isElection = true
-		}
-
-		if *isElection {
-			*timeSinceLastUpdate = time.Now()
-			go elect(state, voteChannels, *onWinChannel)
-		}
-
-		time.Sleep(electionThreadSleepTime)
 	}
 }
 
@@ -181,196 +148,5 @@ func processAppendEntryRequest(appendEntryRequest AppendEntriesMessage, state *S
 			// respond to leader, append succeeded
 			appendEntriesCom[state.ServerId].response <- AppendEntriesResponse{state.CurrentTerm, true, appendEntryRequest}
 		}
-	}
-}
-
-func runHeartbeatThread(
-	state * ServerState, 
-	appendEntriesCom *[ClusterSize]AppendEntriesCom) {
-	for state.Role == LeaderRole {
-		for _, leaderCommunicationChannel := range *appendEntriesCom {
-			leaderCommunicationChannel.message <- AppendEntriesMessage{
-				// leader's term
-				state.CurrentTerm,
-				
-				// leader's ID
-				state.ServerId,
-				
-				// index of last entry in log
-				len(state.Log),
-				
-				// term of last entry in log
-				state.CurrentTerm,
-				
-				// list of logentries to store
-				// ** empty for heartbeat **
-				[]LogEntry{},
-
-				// leader's current commit index
-				state.commitIndex}
-		}
-		time.Sleep(time.Duration(HeartBeatDelay) * time.Millisecond)
-	}
-}
-
-//TODO: update commitindex on majority
-//TODO: respond to client
-func readAndDistributeClientRequests(
-	state * ServerState, 
-	serverLeaderStates *[ClusterSize]LeaderState,
-	appendEntriesCom *[ClusterSize]AppendEntriesCom,
-	clientCommunicationChannel * chan KeyValue) {
-
-	/* AppendEntriesResponse Handlers
-	 * For each server a goroutine is created that continuously reads AppendEntries resopnses
-	 */
-	for serverIndex, leaderCommunicationChannel := range *appendEntriesCom {
-		leaderCommunicationChannel := leaderCommunicationChannel
-		serverIndex := serverIndex
-		go func () {
-			for state.Role == LeaderRole {
-				select {
-				case r := <- leaderCommunicationChannel.response:
-					// TODO: why does the paper say to respond with a term?!
-					if r.success {
-						// update matchIndex and nextIndex on successful appendEntry
-						serverLeaderStates[serverIndex].matchIndex = r.message.PrevLogIndex + len(r.message.Entries)
-						serverLeaderStates[serverIndex].nextIndex = serverLeaderStates[serverIndex].matchIndex + 1
-					} else {
-						// resend message with more logEntries on failure
-						serverLeaderStates[serverIndex].nextIndex -= 1
-						go sendAppend(leaderCommunicationChannel, state, serverLeaderStates[serverIndex])
-					}
-				default:
-					// do nothing
-				}
-			}
-		}()
-	}
-
-	/* AppendEntriesRequest Handler
-	 * Distributes a client request to all servers in the system.
-	 */
-	for state.Role == LeaderRole {
-		select {
-		case clientRequest := <-*clientCommunicationChannel:
-			fmt.Println("received entry from client.")
-			// Append to leader log
-			state.Log = append(state.Log, LogEntry{state.CurrentTerm, clientRequest})
-			state.lastApplied++
-
-			for serverIndex, leaderCommunicationChannel := range *appendEntriesCom {
-				go sendAppend(leaderCommunicationChannel, state, serverLeaderStates[serverIndex])
-			}
-		} 
-	}
-}
-
-func sendAppend(appendEntriesCom AppendEntriesCom, state *ServerState, leaderState LeaderState) {
-	appendEntriesCom.message <- AppendEntriesMessage {
-		// leader's term
-		state.CurrentTerm,
-		
-		// leader's ID
-		state.ServerId,
-		
-		// index of previous entry in log
-		leaderState.nextIndex - 1,
-		
-		// term of previous entry in log
-		state.Log[leaderState.nextIndex - 1].Term,
-		
-		// new LogEntries to store
-		// from nextIndex to end of log
-		state.Log[leaderState.nextIndex - 1:],
-
-		// leader's current commit index
-		state.commitIndex}
-}
-
-func printMessageFromLeader(id int, message AppendEntriesMessage){
-	if debug && len(message.Entries) > 0 {
-		printMessage(id, message)
-	} else {
-		//fmt.Println(id, " received heartbeat from ", message.LeaderId)
-	}
-}
-
-func printMessage(id int, message AppendEntriesMessage) {
-	fmt.Println("Server ", id, " received new entry from ", message.LeaderId, ": ")
-	fmt.Println("\tEntries to message: ", message.Entries)
-	fmt.Println("\tPrevious index: ", message.PrevLogIndex)
-	fmt.Println("\tPrevious term: ", message.PrevLogTerm)
-	fmt.Println("\tLeader term: ", message.Term)
-}
-
-/* Begins an election and handles the following events:
- * 1. Election timeout reaches threshold -> Become candidate
- * 2. External Request to vote -> Give vote, ignore if voted already
- */
-func elect(
-	state * ServerState,
-	voteChannels *[ClusterSize]chan Vote,
-	onWinChannel chan bool,
-	) {
-	timeUntilElectionStart := rand.Intn(150) + 150
-	electionStartTimer := time.NewTimer(time.Duration(timeUntilElectionStart) * time.Millisecond)
-	serverStateLock := new(sync.Mutex)
-
-	select {
-	case <-electionStartTimer.C: // candidate
-		// lock while transitioning to candidate
-		serverStateLock.Lock()
-		state.CurrentTerm++
-		state.Role = CandidateRole
-		state.VotedFor = state.ServerId // vote for self
-		serverStateLock.Unlock()
-		
-		//count votes
-		go requestVotes(state, voteChannels, onWinChannel)
-
-
-	/* Response handler for vote requests.
-	 * Note, CurrentTerm is used as a flag to identify if a server has voted.
-	 * If vote request contains a future term, then vote is confirmed and CurrentTerm updated to reject any
-	 * other candidate running in the same term.
-	 */
-	case voteRequest := <-(*voteChannels)[state.ServerId]: //
-		serverStateLock.Lock()
-		if voteRequest.Term > state.CurrentTerm { // I haven't voted yet (noted by stale term)
-			state.CurrentTerm = voteRequest.Term
-			state.VotedFor = voteRequest.VoteFor
-			serverStateLock.Unlock()
-			voteRequest.Responses <- true
-		} else { //implements RV1.
-			voteRequest.Responses <- false
-		}
-	}
-}
-
-func requestVotes(state * ServerState, voteChannels *[ClusterSize]chan Vote, onWinChannel chan bool) {
-	// send vote requests to other servers
-	//TODO: What if one of the servers is down -- then this will hang forever
-	responses := make(chan bool)
-	for i, c := range *voteChannels {
-		if i != state.ServerId {
-			c <- Vote{state.CurrentTerm, state.ServerId, responses}
-		}
-	}
-	
-	// count votes
-	votes := 0
-	for j := 0; j < (ClusterSize - 1); j++ {
-		r := <-responses
-		if r {
-			votes++
-		}
-	}
-
-	if votes >= ClusterSize/2 { // implements c2.
-		fmt.Print("Server ", state.ServerId, " is the leader!\n\n")
-		onWinChannel <- true
-	} else {
-		fmt.Println("Server ", state.ServerId, " lost the election.")
 	}
 }

--- a/debughelpers.go
+++ b/debughelpers.go
@@ -1,0 +1,1 @@
+package main

--- a/debughelpers.go
+++ b/debughelpers.go
@@ -1,1 +1,20 @@
 package main
+
+import "fmt"
+
+func printMessageFromLeader(id int, message AppendEntriesMessage) {
+	if debug && len(message.Entries) > 0 {
+		printMessage(id, message)
+	} else {
+		//fmt.Println(id, " received heartbeat from ", message.LeaderId)
+	}
+}
+
+func printMessage(id int, message AppendEntriesMessage) {
+	fmt.Println("Server ", id, " received new entry from ", message.LeaderId, ": ")
+	fmt.Println("\tEntries to message: ", message.Entries)
+	fmt.Println("\tPrevious index: ", message.PrevLogIndex)
+	fmt.Println("\tPrevious term: ", message.PrevLogTerm)
+	fmt.Println("\tLeader term: ", message.Term)
+}
+

--- a/election.go
+++ b/election.go
@@ -1,0 +1,1 @@
+package main

--- a/election.go
+++ b/election.go
@@ -1,1 +1,79 @@
 package main
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+/* Begins an election and handles the following events:
+ * 1. Election timeout reaches threshold -> Become candidate
+ * 2. External Request to vote -> Give vote, ignore if voted already
+ */
+func elect(
+	state *ServerState,
+	voteChannels *[ClusterSize]chan Vote,
+	onWinChannel chan bool,
+) {
+	timeUntilElectionStart := rand.Intn(150) + 150
+	electionStartTimer := time.NewTimer(time.Duration(timeUntilElectionStart) * time.Millisecond)
+	serverStateLock := new(sync.Mutex)
+
+	select {
+	case <-electionStartTimer.C: // candidate
+		// lock while transitioning to candidate
+		serverStateLock.Lock()
+		state.CurrentTerm++
+		state.Role = CandidateRole
+		state.VotedFor = state.ServerId // vote for self
+		serverStateLock.Unlock()
+
+		//count votes
+		go requestVotes(state, voteChannels, onWinChannel)
+
+
+	/* Response handler for vote requests.
+	 * Note, CurrentTerm is used as a flag to identify if a server has voted.
+	 * If vote request contains a future term, then vote is confirmed and CurrentTerm updated to reject any
+	 * other candidate running in the same term.
+	 */
+	case voteRequest := <-(*voteChannels)[state.ServerId]: //
+		serverStateLock.Lock()
+		if voteRequest.Term > state.CurrentTerm { // I haven't voted yet (noted by stale term)
+			state.CurrentTerm = voteRequest.Term
+			state.VotedFor = voteRequest.VoteFor
+			serverStateLock.Unlock()
+			voteRequest.Responses <- true
+		} else { //implements RV1.
+			voteRequest.Responses <- false
+		}
+	}
+}
+
+func requestVotes(state *ServerState, voteChannels *[ClusterSize]chan Vote, onWinChannel chan bool) {
+	// send vote requests to other servers
+	//TODO: What if one of the servers is down -- then this will hang forever
+	responses := make(chan bool)
+	for i, c := range *voteChannels {
+		if i != state.ServerId {
+			c <- Vote{state.CurrentTerm, state.ServerId, responses}
+		}
+	}
+
+	// count votes
+	votes := 0
+	for j := 0; j < (ClusterSize - 1); j++ {
+		r := <-responses
+		if r {
+			votes++
+		}
+	}
+
+	if votes >= ClusterSize/2 { // implements c2.
+		fmt.Print("Server ", state.ServerId, " is the leader!\n\n")
+		onWinChannel <- true
+	} else {
+		fmt.Println("Server ", state.ServerId, " lost the election.")
+	}
+}

--- a/leader.go
+++ b/leader.go
@@ -1,0 +1,1 @@
+package main

--- a/leader.go
+++ b/leader.go
@@ -1,1 +1,143 @@
 package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+//TODO: update commitindex on majority
+//TODO: respond to client
+func readAndDistributeClientRequests(
+	state *ServerState,
+	serverLeaderStates *[ClusterSize]LeaderState,
+	appendEntriesCom *[ClusterSize]AppendEntriesCom,
+	clientCommunicationChannel *chan KeyValue) {
+
+	/* AppendEntriesResponse Handlers
+	 * For each server a goroutine is created that continuously reads AppendEntries resopnses
+	 */
+	for serverIndex, leaderCommunicationChannel := range *appendEntriesCom {
+		leaderCommunicationChannel := leaderCommunicationChannel
+		serverIndex := serverIndex
+		go func() {
+			for state.Role == LeaderRole {
+				select {
+				case r := <-leaderCommunicationChannel.response:
+					// TODO: why does the paper say to respond with a term?!
+					if r.success {
+						// update matchIndex and nextIndex on successful appendEntry
+						serverLeaderStates[serverIndex].matchIndex = r.message.PrevLogIndex + len(r.message.Entries)
+						serverLeaderStates[serverIndex].nextIndex = serverLeaderStates[serverIndex].matchIndex + 1
+					} else {
+						// resend message with more logEntries on failure
+						serverLeaderStates[serverIndex].nextIndex -= 1
+						go sendAppend(leaderCommunicationChannel, state, serverLeaderStates[serverIndex])
+					}
+				default:
+					// do nothing
+				}
+			}
+		}()
+	}
+
+	/* AppendEntriesRequest Handler
+	 * Distributes a client request to all servers in the system.
+	 */
+	for state.Role == LeaderRole {
+		select {
+		case clientRequest := <-*clientCommunicationChannel:
+			fmt.Println("received entry from client.")
+			// Append to leader log
+			state.Log = append(state.Log, LogEntry{state.CurrentTerm, clientRequest})
+			state.lastApplied++
+
+			for serverIndex, leaderCommunicationChannel := range *appendEntriesCom {
+				go sendAppend(leaderCommunicationChannel, state, serverLeaderStates[serverIndex])
+			}
+		}
+	}
+}
+
+func runHeartbeatThread(
+	state *ServerState,
+	appendEntriesCom *[ClusterSize]AppendEntriesCom) {
+	for state.Role == LeaderRole {
+		for _, leaderCommunicationChannel := range *appendEntriesCom {
+			leaderCommunicationChannel.message <- AppendEntriesMessage{
+				// leader's term
+				state.CurrentTerm,
+
+				// leader's ID
+				state.ServerId,
+
+				// index of last entry in log
+				len(state.Log),
+
+				// term of last entry in log
+				state.CurrentTerm,
+
+				// list of logentries to store
+				// ** empty for heartbeat **
+				[]LogEntry{},
+
+				// leader's current commit index
+				state.commitIndex}
+		}
+		time.Sleep(time.Duration(HeartBeatDelay) * time.Millisecond)
+	}
+}
+
+/* On Win Handler. Responsibilities includes
+ * - updating role of server to leader
+ * - running heartbeat thread
+ * - managing client requests (in progress)
+ */
+func onWinChannelListener(
+	state *ServerState,
+	onWinChannel *chan bool,
+	serverStateLock *sync.Mutex,
+	appendEntriesCom *[8]AppendEntriesCom,
+	clientCommunicationChannel *chan KeyValue) {
+	//TODO: What if received message from new leader before onWinChannel gets to hear about it?
+	for {
+		select {
+		case <-* onWinChannel: // got enough votes
+			serverStateLock.Lock()
+			state.Role = LeaderRole
+			serverStateLock.Unlock()
+
+			// initialize leader state
+			var leaderState [ClusterSize]LeaderState
+			for i := 0; i < ClusterSize; i++ {
+				// Note that logentries are indexed from 1
+				leaderState[i] = LeaderState{len(state.Log) + 1, 0}
+			}
+
+			go runHeartbeatThread(state, appendEntriesCom) // Implements L1.
+			go readAndDistributeClientRequests(state, &leaderState, appendEntriesCom, clientCommunicationChannel)
+		}
+	}
+}
+
+func sendAppend(appendEntriesCom AppendEntriesCom, state *ServerState, leaderState LeaderState) {
+	appendEntriesCom.message <- AppendEntriesMessage {
+		// leader's term
+		state.CurrentTerm,
+
+		// leader's ID
+		state.ServerId,
+
+		// index of previous entry in log
+		leaderState.nextIndex - 1,
+
+		// term of previous entry in log
+		state.Log[leaderState.nextIndex - 1].Term,
+
+		// new LogEntries to store
+		// from nextIndex to end of log
+		state.Log[leaderState.nextIndex - 1:],
+
+		// leader's current commit index
+		state.commitIndex}
+}

--- a/raft.go
+++ b/raft.go
@@ -18,13 +18,26 @@ func main() {
 	fmt.Print("Creating cluster...\n")
 	initCluster(clientCommunicationChannel, TestPersister{})
 
-	reader := bufio.NewReader(os.Stdin)
-
 	for {
-		fmt.Print("Enter Key, Value pair: ")
-		text, _ := reader.ReadString('\n')
-		pair := strings.Split(text, ",")
+		pair := promptForKeyValuePair(true)
 		clientCommunicationChannel <-KeyValue{pair[0], pair[1]}
 	}
+}
+
+func promptForKeyValuePair(loopUntilValid bool) []string {
+	pair := keyValuePrompt()
+	for len(pair) != 2 {
+		fmt.Print("Expected 2 elements received ", len(pair), " elements.")
+		pair = keyValuePrompt()
+	}
+	return pair
+}
+
+func keyValuePrompt() []string {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Println("Enter Key-Value pair (K,V): ")
+	text, _ := reader.ReadString('\n')
+	pair := strings.Split(text, ",")
+	return pair
 }
 

--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,1 @@
-go run types.go cluster.go TestPersister.go raftstate.go raft.go
+go run debughelpers.go types.go election.go leader.go  cluster.go TestPersister.go raftstate.go raft.go

--- a/types.go
+++ b/types.go
@@ -63,7 +63,7 @@ type AppendEntriesResponse struct {
 	message AppendEntriesMessage
 }
 
-type LeaderCom struct {
+type AppendEntriesCom struct {
 	/* Messages from client to cluster
 	 *
 	 */


### PR DESCRIPTION
+ Leader ignore AppendEntries from itself as to not update twice. Update is already handles as a part of the leader logic.
+ Election starts immediately at cluster initialization
+ Renamed LeaderCom to `AppendEntriesCom` since the message and response have `AppendEntries` in their names