### PR TITLE
system can stores a persistent log that it loads from upon startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/*.iml
 **/*.xml
+TestLog.csv

--- a/IOHelper.go
+++ b/IOHelper.go
@@ -1,0 +1,1 @@
+package main

--- a/IOHelper.go
+++ b/IOHelper.go
@@ -1,1 +1,68 @@
 package main
+
+import (
+	"encoding/csv"
+	"io"
+	"log"
+	"os"
+	"strconv"
+)
+
+func logEntryAsCVSEntry(logEntry LogEntry) []string {
+	return []string{strconv.Itoa(logEntry.Term), logEntry.Content.Key, logEntry.Content.Value}
+}
+
+func readLogEntryCSVFile(fileName string) []LogEntry {
+	var logEntries []LogEntry
+	// Open the file
+	csvFile, err := os.Open(fileName)
+	if err != nil {
+		log.Fatalln("Couldn't open the csv file", err)
+	}
+
+	// Parse the file
+	r := csv.NewReader(csvFile)
+	//r := csv.NewReader(bufio.NewReader(csvFile))
+
+	// Iterate through the records
+	for {
+		// Read each record from csv
+		record, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
+		term, err := strconv.Atoi(record[0])
+		key := record[1]
+		value := record[2]
+		logEntryContent := KeyValue{key, value}
+		logEntry := LogEntry{term, logEntryContent}
+		logEntries = append(logEntries, logEntry)
+	}
+	return logEntries
+}
+
+func addEntryToFile(fileName string, row []string) {
+	file, err := os.OpenFile(fileName,
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Println(err)
+	}
+
+	checkError("Cannot create file", err)
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	err = writer.Write(row)
+	checkError("Cannot write to file", err)
+}
+
+func checkError(message string, err error) {
+	if err != nil {
+		log.Fatal(message, err)
+	}
+}

--- a/TestPersister.go
+++ b/TestPersister.go
@@ -13,7 +13,7 @@ import (
 const TestLogFileName = "TestLog.csv" //the name of the log
 
 type TestPersister struct {
-	inMemoryLog * []LogEntry
+	inMemoryLog * []LogEntry //used to load and store list during normal operation. Used mostly for testing purposes.
 }
 
 func createTestPersister() TestPersister {

--- a/TestPersister.go
+++ b/TestPersister.go
@@ -4,7 +4,13 @@ import (
 	"fmt"
 )
 
-const TestLogFileName = "TestLog.csv"
+/* TestPersister is a testing library that writes to a file in a csv format.
+ * Each line corresponds to a LogEntry. Each line has three values"
+ * 1. Term
+ * 2. Key
+ * 3. Value
+ */
+const TestLogFileName = "TestLog.csv" //the name of the log
 
 type TestPersister struct {
 	inMemoryLog * []LogEntry
@@ -22,7 +28,7 @@ func createTestPersister() TestPersister {
  */
 func (t TestPersister) Save(id string, logEntry LogEntry) error {
 	*t.inMemoryLog = append(*t.inMemoryLog, logEntry)
-	addEntryToFile(TestLogFileName, logEntryAsCVSEntry(logEntry))
+	addEntryToCSVFile(TestLogFileName, logEntryAsCVSEntry(logEntry))
 	fmt.Println("saving log entry to persister. New entries this session: ", len(*t.inMemoryLog))
 
 	return nil
@@ -32,7 +38,7 @@ func (t TestPersister) Save(id string, logEntry LogEntry) error {
  *
  */
 func (t TestPersister) Load(loadFunc LoadFunc) error {
-	*t.inMemoryLog = readLogEntryCSVFile(TestLogFileName)
+	*t.inMemoryLog = readLogEntriesFromCSVFile(TestLogFileName)
 	fmt.Println("Loaded ", len(*t.inMemoryLog), " many entries from persistent state.")
 	return nil
 }

--- a/TestPersister.go
+++ b/TestPersister.go
@@ -3,11 +3,12 @@ package main
 import "fmt"
 
 type TestPersister struct {
-
+	entriesSinceStart * []LogEntry
 }
 
-func (t TestPersister) Save(id string, logEntry interface{}) error {
-	fmt.Println("saving log entry to persister: ", logEntry)
+func (t TestPersister) Save(id string, logEntry LogEntry) error {
+	*t.entriesSinceStart = append(*t.entriesSinceStart, logEntry)
+	fmt.Println("saving log entry to persister. New total entries: ", len(*t.entriesSinceStart))
 	return nil
 }
 

--- a/TestPersister.go
+++ b/TestPersister.go
@@ -30,7 +30,7 @@ func createTestPersister() TestPersister {
 func (t TestPersister) Save(id string, logEntry LogEntry) error {
 	*t.inMemoryLog = append(*t.inMemoryLog, logEntry)
 	addEntryToCSVFile(TestLogFileName, logEntryAsCVSEntry(logEntry))
-	fmt.Println("saving log entry to persister. New entries this session: ", len(*t.inMemoryLog))
+	fmt.Println("saving log entry to persister. New size of log: ", len(*t.inMemoryLog))
 
 	return nil
 }

--- a/TestPersister.go
+++ b/TestPersister.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 )
 
 /* TestPersister is a testing library that writes to a file in a csv format.
@@ -38,7 +39,11 @@ func (t TestPersister) Save(id string, logEntry LogEntry) error {
  *
  */
 func (t TestPersister) Load(loadFunc LoadFunc) error {
-	*t.inMemoryLog = readLogEntriesFromCSVFile(TestLogFileName)
+	loadedLogEntries := readLogEntriesFromCSVFile(TestLogFileName)
+	*t.inMemoryLog = loadedLogEntries
+	for logEntryIndex, logEntry := range loadedLogEntries {
+		loadFunc(strconv.Itoa(logEntryIndex), logEntry)
+	}
 	fmt.Println("Loaded ", len(*t.inMemoryLog), " many entries from persistent state.")
 	return nil
 }

--- a/TestPersister.go
+++ b/TestPersister.go
@@ -1,22 +1,48 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+)
+
+const TestLogFileName = "TestLog.csv"
 
 type TestPersister struct {
-	entriesSinceStart * []LogEntry
+	inMemoryLog * []LogEntry
 }
 
+func createTestPersister() TestPersister {
+	var logBuffer []LogEntry
+	persister := TestPersister{}
+	persister.inMemoryLog = &logBuffer
+	return persister
+}
+
+/* Adds a line csv row to the log corresponding to given log entry.
+ *
+ */
 func (t TestPersister) Save(id string, logEntry LogEntry) error {
-	*t.entriesSinceStart = append(*t.entriesSinceStart, logEntry)
-	fmt.Println("saving log entry to persister. New total entries: ", len(*t.entriesSinceStart))
+	*t.inMemoryLog = append(*t.inMemoryLog, logEntry)
+	addEntryToFile(TestLogFileName, logEntryAsCVSEntry(logEntry))
+	fmt.Println("saving log entry to persister. New entries this session: ", len(*t.inMemoryLog))
+
 	return nil
 }
 
+/* Reads CSV log and creates log entry per file.
+ *
+ */
 func (t TestPersister) Load(loadFunc LoadFunc) error {
-	fmt.Println("loading from persister...")
+	*t.inMemoryLog = readLogEntryCSVFile(TestLogFileName)
+	fmt.Println("Loaded ", len(*t.inMemoryLog), " many entries from persistent state.")
 	return nil
 }
 
+/* Removes a line in the log given the id of the entry.
+ *
+ */
 func (t TestPersister) Remove(id string) error {
 	panic("implement me")
 }
+
+
+

--- a/cluster.go
+++ b/cluster.go
@@ -28,7 +28,7 @@ func initCluster(clientCommunicationChannel chan KeyValue, persister Persister) 
 	currentTerm := 0
 
 	if len(previousLogEntries) > 0 {
-		currentTerm = previousLogEntries[len(previousLogEntries)-1].Term //set to start new term
+		currentTerm = previousLogEntries[len(previousLogEntries)-1].Term
 	}
 
 	// Spawn 8 nodes (all followers to start)

--- a/cluster.go
+++ b/cluster.go
@@ -132,6 +132,7 @@ func processAppendEntryRequest(appendEntryRequest AppendEntriesMessage, state *S
 			for _, entry := range appendEntryRequest.Entries {
 				state.Log = append(state.Log, entry)
 			}
+			appendEntriesCom[state.ServerId].response <- AppendEntriesResponse{state.CurrentTerm, true, appendEntryRequest}
 		} else if appendEntryRequest.PrevLogIndex > len(state.Log) ||
 			state.Log[appendEntryRequest.PrevLogIndex-1].Term != appendEntryRequest.PrevLogTerm {
 			// respond to leader, append failed (need more entries)

--- a/cluster.go
+++ b/cluster.go
@@ -152,16 +152,16 @@ func processAppendEntryRequest(appendEntryRequest AppendEntriesMessage, state *S
 			return
 		}
 
+		if appendEntryRequest.PrevLogIndex <= len(state.Log) { //implements AE3.
+			state.Log = append(state.Log[:appendEntryRequest.PrevLogIndex], appendEntryRequest.Entries...) //not shifting index because slice ignores upper bound
+			onSuccess()
+			return
+		}
+
 		if appendEntryRequest.PrevLogIndex > len(state.Log) ||
 			state.Log[appendEntryRequest.PrevLogIndex-1].Term != appendEntryRequest.PrevLogTerm { //implements AE2.
 			// respond to leader, append failed (need more entries)
 			onFail()
-			return
-		}
-
-		if appendEntryRequest.PrevLogIndex <= len(state.Log) { //implements AE3 + AE4
-			state.Log = append(state.Log[:appendEntryRequest.PrevLogIndex], appendEntryRequest.Entries...) //not shifting index because slice ignores upper bound
-			onSuccess()
 			return
 		}
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -152,16 +152,16 @@ func processAppendEntryRequest(appendEntryRequest AppendEntriesMessage, state *S
 			return
 		}
 
-		if appendEntryRequest.PrevLogIndex <= len(state.Log) { //implements AE3.
-			state.Log = append(state.Log[:appendEntryRequest.PrevLogIndex], appendEntryRequest.Entries...) //not shifting index because slice ignores upper bound
-			onSuccess()
-			return
-		}
-
 		if appendEntryRequest.PrevLogIndex > len(state.Log) ||
 			state.Log[appendEntryRequest.PrevLogIndex-1].Term != appendEntryRequest.PrevLogTerm { //implements AE2.
 			// respond to leader, append failed (need more entries)
 			onFail()
+			return
+		}
+
+		if appendEntryRequest.PrevLogIndex <= len(state.Log) { //implements AE3 + AE4
+			state.Log = append(state.Log[:appendEntryRequest.PrevLogIndex], appendEntryRequest.Entries...) //not shifting index because slice ignores upper bound
+			onSuccess()
 			return
 		}
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -32,12 +32,12 @@ func initCluster(clientCommunicationChannel chan KeyValue, persister Persister) 
 	}
 
 	// Spawn 8 nodes (all followers to start)
-	for i := 0; i < ClusterSize; i++ {
+	for serverIndex := 0; serverIndex < ClusterSize; serverIndex++ {
 		// initialize state as followers
-		state := ServerState{i, currentTerm, -1, previousLogEntries, FollowerRole, lastCommittedIndex,lastCommittedIndex}
+		state := ServerState{serverIndex, currentTerm, -1, previousLogEntries, FollowerRole, lastCommittedIndex,lastCommittedIndex}
 
-		voteChannels[i] = make(chan Vote)
-		appendEntriesCom[i] = AppendEntriesCom{make(chan AppendEntriesMessage), make(chan AppendEntriesResponse)}
+		voteChannels[serverIndex] = make(chan Vote)
+		appendEntriesCom[serverIndex] = AppendEntriesCom{make(chan AppendEntriesMessage), make(chan AppendEntriesResponse)}
 
 		go startServer(&state, &voteChannels, &appendEntriesCom, clientCommunicationChannel, persister)
 	}
@@ -93,7 +93,7 @@ func runElectionTimeoutThread(
 }
 
 /* Handles messages from leader. Duties include:
-* - ignore anything with stale term
+ * - ignore anything with stale term
  * - update timeSinceLastUpdate
  * - process new log entries + heartbeats (empty logs)
 */
@@ -115,7 +115,7 @@ func startLeaderListener(
 				}
 
 				printMessageFromLeader(state.ServerId, appendEntryRequest)
-				if state.Role != LeaderRole { //processed separately before all others
+				if state.Role != LeaderRole { //processed separately once consensus is reached
 					processAppendEntryRequest(appendEntryRequest, state, appendEntriesCom)
 				}
 			}

--- a/leader.go
+++ b/leader.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -16,7 +17,9 @@ func onWinChannelListener(
 	onWinChannel *chan bool,
 	serverStateLock *sync.Mutex,
 	appendEntriesCom *[8]AppendEntriesCom,
-	clientCommunicationChannel *chan KeyValue) {
+	clientCommunicationChannel *chan KeyValue,
+	persister Persister,
+	) {
 	//TODO: What if received message from new leader before onWinChannel gets to hear about it?
 	for {
 		select {
@@ -33,7 +36,7 @@ func onWinChannelListener(
 			}
 
 			go runHeartbeatThread(state, appendEntriesCom) // Implements L1.
-			go readAndDistributeClientRequests(state, &leaderState, appendEntriesCom, clientCommunicationChannel)
+			go readAndDistributeClientRequests(state, &leaderState, appendEntriesCom, clientCommunicationChannel, persister)
 		}
 	}
 }
@@ -73,7 +76,9 @@ func readAndDistributeClientRequests(
 	state *ServerState,
 	serverLeaderStates *[ClusterSize]LeaderState,
 	appendEntriesCom *[ClusterSize]AppendEntriesCom,
-	clientCommunicationChannel *chan KeyValue) {
+	clientCommunicationChannel *chan KeyValue,
+	persister Persister,
+	) {
 
 	/* AppendEntriesRequest Handler
 	 * Distributes a client request to all servers in the system.
@@ -81,15 +86,20 @@ func readAndDistributeClientRequests(
 	for state.Role == LeaderRole {
 		select {
 		case clientRequest := <-*clientCommunicationChannel:
-			fmt.Println("received entry from client.")
+
+			clientLogEntry := LogEntry{state.CurrentTerm, clientRequest}
 
 			for serverIndex, leaderCommunicationChannel := range *appendEntriesCom {
-				go sendAppendEntriesMessage(leaderCommunicationChannel, state, serverLeaderStates[serverIndex])
+				go sendAppendEntriesMessage(leaderCommunicationChannel, []LogEntry{clientLogEntry}, state, serverLeaderStates[serverIndex])
 			}
 
 			//TODO: Leader should not commit to state until signal that majority received log entry
 			state.Log = append(state.Log, LogEntry{state.CurrentTerm, clientRequest})
 			state.lastApplied++
+			err := persister.Save(strconv.Itoa(len(state.Log)), clientLogEntry)
+			for err != nil { //retry until no error.
+				err = persister.Save(strconv.Itoa(len(state.Log)), clientLogEntry)
+			}
 		}
 	}
 
@@ -109,9 +119,15 @@ func readAndDistributeClientRequests(
 						serverLeaderStates[serverIndex].matchIndex = r.message.PrevLogIndex + len(r.message.Entries)
 						serverLeaderStates[serverIndex].nextIndex = serverLeaderStates[serverIndex].matchIndex + 1
 					} else {
+						fmt.Println("Error processing AppendEntries request: ", r.message)
 						// resend message with more logEntries on failure
-						serverLeaderStates[serverIndex].nextIndex -= 1
-						go sendAppendEntriesMessage(leaderCommunicationChannel, state, serverLeaderStates[serverIndex])
+						serverLeaderStates[serverIndex].nextIndex -= 1 //
+						nextIndexLog := state.Log[serverLeaderStates[serverIndex].nextIndex]
+						go sendAppendEntriesMessage(
+							leaderCommunicationChannel,
+							[]LogEntry{nextIndexLog},
+							state,
+							serverLeaderStates[serverIndex])
 					}
 				default:
 					// do nothing
@@ -121,7 +137,14 @@ func readAndDistributeClientRequests(
 	}
 }
 
-func sendAppendEntriesMessage(appendEntriesCom AppendEntriesCom, state *ServerState, leaderState LeaderState) {
+func sendAppendEntriesMessage(
+	appendEntriesCom AppendEntriesCom,
+	entries []LogEntry,
+	state * ServerState,
+	leaderState LeaderState,
+	) {
+	prevLogIndex := leaderState.nextIndex - 1
+
 	appendEntriesCom.message <- AppendEntriesMessage {
 		// leader's term
 		state.CurrentTerm,
@@ -130,14 +153,14 @@ func sendAppendEntriesMessage(appendEntriesCom AppendEntriesCom, state *ServerSt
 		state.ServerId,
 
 		// index of previous entry in log
-		leaderState.nextIndex - 1,
+		prevLogIndex,
 
 		// term of previous entry in log
 		state.Log[leaderState.nextIndex - 1].Term,
 
 		// new LogEntries to store
 		// from nextIndex to end of log
-		state.Log[leaderState.nextIndex - 1:],
+		entries,
 
 		// leader's current commit index
 		state.commitIndex}

--- a/leader.go
+++ b/leader.go
@@ -144,6 +144,10 @@ func sendAppendEntriesMessage(
 	leaderState LeaderState,
 	) {
 	prevLogIndex := leaderState.nextIndex - 1
+	prevLogTerm := -1
+	if prevLogIndex >= 1 { //recall indexing starts at 1
+		prevLogTerm = state.Log[prevLogIndex].Term
+	}
 
 	appendEntriesCom.message <- AppendEntriesMessage {
 		// leader's term
@@ -156,7 +160,7 @@ func sendAppendEntriesMessage(
 		prevLogIndex,
 
 		// term of previous entry in log
-		state.Log[leaderState.nextIndex - 1].Term,
+		prevLogTerm,
 
 		// new LogEntries to store
 		// from nextIndex to end of log

--- a/logoperations.go
+++ b/logoperations.go
@@ -54,8 +54,7 @@ func readLogEntriesFromCSVFile(fileName string) []LogEntry {
 }
 
 func addEntryToCSVFile(fileName string, row []string) {
-	file, err := os.OpenFile(fileName,
-		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 
 	checkError("Error opening file:", err)
 	defer file.Close()

--- a/logoperations.go
+++ b/logoperations.go
@@ -25,9 +25,7 @@ func CSVEntryAsLogEntry(logEntry []string) LogEntry {
 		log.Fatal("Row had too few or too many values:", len(logEntry))
 	}
 	term, err := strconv.Atoi(logEntry[0])
-	if err != nil {
-		log.Fatal("Entry term number could not parsed into a number: ", logEntry[0])
-	}
+	checkError("Entry term number could not parsed into a number: ", err)
 
 	logEntryContent := KeyValue{logEntry[1], logEntry[2]}
 	logEntryParsed := LogEntry{term, logEntryContent}
@@ -36,11 +34,9 @@ func CSVEntryAsLogEntry(logEntry []string) LogEntry {
 
 func readLogEntriesFromCSVFile(fileName string) []LogEntry {
 	var logEntries []LogEntry
-	csvFile, err := os.OpenFile(fileName,
-		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		log.Fatalln("Couldn't open the csv file", err)
-	}
+	csvFile, err := os.Open(fileName)
+
+	checkError("Couldn't open the csv file", err)
 	r := csv.NewReader(csvFile)
 
 	// Iterate through the records
@@ -49,9 +45,7 @@ func readLogEntriesFromCSVFile(fileName string) []LogEntry {
 		if err == io.EOF {
 			break
 		}
-		if err != nil {
-			log.Fatal(err)
-		}
+		checkError("Error reading record in file:", err)
 
 		logEntry := CSVEntryAsLogEntry(record)
 		logEntries = append(logEntries, logEntry)
@@ -62,11 +56,8 @@ func readLogEntriesFromCSVFile(fileName string) []LogEntry {
 func addEntryToCSVFile(fileName string, row []string) {
 	file, err := os.OpenFile(fileName,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		log.Println(err)
-	}
 
-	checkError("Cannot create file", err)
+	checkError("Error opening file:", err)
 	defer file.Close()
 
 	writer := csv.NewWriter(file)

--- a/logoperations.go
+++ b/logoperations.go
@@ -34,7 +34,7 @@ func CSVEntryAsLogEntry(logEntry []string) LogEntry {
 	return logEntryParsed
 }
 
-func readLogEntryCSVFile(fileName string) []LogEntry {
+func readLogEntriesFromCSVFile(fileName string) []LogEntry {
 	var logEntries []LogEntry
 	csvFile, err := os.OpenFile(fileName,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -59,7 +59,7 @@ func readLogEntryCSVFile(fileName string) []LogEntry {
 	return logEntries
 }
 
-func addEntryToFile(fileName string, row []string) {
+func addEntryToCSVFile(fileName string, row []string) {
 	file, err := os.OpenFile(fileName,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {

--- a/persister.go
+++ b/persister.go
@@ -2,8 +2,6 @@ package main
 
 import "fmt"
 
-const StateFileName = "ApplicationState.txt"
-
 /* Had a lot of trouble finding persister.go libary. This is the as close as I got:
  * https://godoc.org/github.com/nedscode/memdb/persist#LoadFunc
  *

--- a/persister.go
+++ b/persister.go
@@ -7,7 +7,7 @@ import "fmt"
  *
  * I couldn't download it but I imagined it would look something like this:
  */
-type LoadFunc func(id string, indexer interface{})
+type LoadFunc func(id string, indexer LogEntry)
 
 type Persister interface {
 	// Save is called to request persistent save of the indexer with id
@@ -22,8 +22,8 @@ type Persister interface {
 
 func initializeServerStateFromPersister(persister Persister) []LogEntry {
 	var logEntries []LogEntry
-	loadFunc := func(id string, logEntry interface{}){
-		//add logEntry to logEntries
+	loadFunc := func(id string, logEntry LogEntry){
+		logEntries = append(logEntries, logEntry)
 	}
 	loadError := persister.Load(loadFunc)
 	if loadError != nil {

--- a/persister.go
+++ b/persister.go
@@ -13,7 +13,7 @@ type LoadFunc func(id string, indexer interface{})
 
 type Persister interface {
 	// Save is called to request persistent save of the indexer with id
-	Save(id string, indexer interface{}) error
+	Save(id string, entry LogEntry) error
 
 	// Load is called at create time to load all of the persisted items and call loadFunc with each
 	Load(loadFunc LoadFunc) error

--- a/raft.go
+++ b/raft.go
@@ -16,7 +16,8 @@ func main() {
 	// 2. Spawn cluster
 	clientCommunicationChannel := make(chan KeyValue)
 	fmt.Print("Creating cluster...\n")
-	initCluster(clientCommunicationChannel, TestPersister{})
+	var logEntriesInSession []LogEntry
+	initCluster(clientCommunicationChannel, TestPersister{&logEntriesInSession})
 
 	for {
 		pair := promptForKeyValuePair(true)

--- a/raft.go
+++ b/raft.go
@@ -16,8 +16,7 @@ func main() {
 	// 2. Spawn cluster
 	clientCommunicationChannel := make(chan KeyValue)
 	fmt.Print("Creating cluster...\n")
-	var logEntriesInSession []LogEntry
-	initCluster(clientCommunicationChannel, TestPersister{&logEntriesInSession})
+	initCluster(clientCommunicationChannel, createTestPersister())
 
 	for {
 		pair := promptForKeyValuePair(true)

--- a/raft.go
+++ b/raft.go
@@ -19,12 +19,12 @@ func main() {
 	initCluster(clientCommunicationChannel, createTestPersister())
 
 	for {
-		pair := promptForKeyValuePair(true)
+		pair := promptForKeyValuePair()
 		clientCommunicationChannel <-KeyValue{pair[0], pair[1]}
 	}
 }
 
-func promptForKeyValuePair(loopUntilValid bool) []string {
+func promptForKeyValuePair() []string {
 	pair := keyValuePrompt()
 	for len(pair) != 2 {
 		fmt.Print("Expected 2 elements received ", len(pair), " elements.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ Requirements for Servers :
         C1. On conversion to candidate, start election. Includes: increment current term, vote for self, reset election timer, send RequestVote RPC to all other servers
             ! Missing resetting election timer
         (DONE) C2. If votes received from majority of serves: become leader
-        3. If AppendEntries RPC received from new leader: convert to follower
+        C3. If AppendEntries RPC received from new leader: convert to follower
             ! Missing check if RPC from leader to leader.
         (DONE) C4. If election timeout elapses: start new election
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,11 @@
 
 RPC Requirements:
     AppendEntries (AE):
-        AE1. Reply false if term < currentTerm
-            ! Replies not implemented.
-        AE2. Reply false if log doesn't contain an entry at prevLogIndex whose term matches prevLogTerm
-            ! Replied not implemented.
-        AE3. If an existing entry conflicts with a new one (same index but different terms), delete the existing entry and all that follow it
-            ! Not implemented.
-        AE4. Append any new entries not already in the log
-            ! Not implemented.
-        AE5. If leaderCommit > commitIndex set commitIndex = ming(leaderCommit, index of last entry)
-            ! Not implemented.
+        (DONE) AE1. Reply false if term < currentTerm
+        (DONE) AE2. Reply false if log doesn't contain an entry at prevLogIndex whose term matches prevLogTerm
+        (DONE) AE3. If an existing entry conflicts with a new one (same index but different terms), delete the existing entry and all that follow it
+        (DONE) AE4. Append any new entries not already in the log
+        (DONE) AE5. If leaderCommit > commitIndex set commitIndex = min(leaderCommit, index of last entry)
 
     Request Vote (RV):
         (DONE) RV1. Reply false if term < currentTerm
@@ -44,12 +39,7 @@ Requirements for Servers :
         (DONE) L1. Upon election: send initial empty AppendEntries RPCs (heartbeat ) to each server; repeat during idle periods to prevent election timeouts
         L2. If command received from client: append entry to local log, respond after entry applied to state machine
             ! Not implemented.
-        L3. If last log index >= nextIndex for a follower: send AppendEntries RPC with log entries starting at nextIndex.
-            ! Not implemented.
-        L3.1 If successful: update nextIndex and matchIndex for follower
-            ! Not implemented.
-        L3.2 If AppendEntries fails because of log inconsistency: decrement nextIndex and retry
-            ! Not implemented.
+        (DONE) L3. If last log index >= nextIndex for a follower: send AppendEntries RPC with log entries starting at nextIndex.
         L4. If there exists an N such that N > commitIndex, a majority of matchIndex[i] >= N, and log[N].term == currentTerm: set commitIndex = N
             ! Not implemented.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,11 +54,10 @@ Requirements for Servers :
             ! Not implemented.
 
 Persistent State Requirements:
-    P1. save and restore persistent state from a Persister object (see persister.go)
-        ! Not implemented.
-    P2. Whoever calls Raft.Make() supplies a Persister that initially holds Raft's most recently persisted state (if any)
-        ! Not implemented.
-    P3. Raft should initialize its state from that Persister, and should use it to save its persistent state each
-        ! Not implemented.
+    (DONE) P1. save and restore persistent state from a Persister object (see persister.go)
+     P2. Whoever calls Raft.Make() supplies a Persister that initially holds Raft's most recently persisted state (if any)
+        ! Raft.Make Not implemented.
+    (DONE) P3. Raft should initialize its state from that Persister, and should use it to save its persistent state each
+
 
 

--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,1 @@
-go run debughelpers.go types.go election.go leader.go  cluster.go TestPersister.go raftstate.go raft.go
+go run debughelpers.go types.go election.go leader.go  cluster.go TestPersister.go persister.go raft.go

--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,1 @@
-go run debughelpers.go types.go election.go leader.go  cluster.go TestPersister.go persister.go raft.go
+go run debughelpers.go types.go election.go leader.go  cluster.go logoperations.go TestPersister.go persister.go raft.go

--- a/types.go
+++ b/types.go
@@ -113,7 +113,7 @@ type ServerState struct {
 	lastApplied int
 }
 
-type LeaderState struct {
+type ServerTermState struct {
 	/* For each server, index of the next log entry to send to that server.
 	 * Initialized to leader last log index + 1.
 	 */


### PR DESCRIPTION
- System loads previous log entries from persister.
- System is able to save log entries when the leader has issued AppendEntries RPC to everyone.
- System waits until consensus is reached on a log entry and then commits and saves entry
- TestPersister uses the disk to write and store log entries

Future Work:

- BUG: If you wait long enough reelections take place and leaders are changed. This is weird because nothing should be failing currently.