### PR TITLE
RV2 - Added LastLogTerm and LastLogIndex to RequestVote RPC

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -15,6 +15,8 @@ type Vote struct {
 	Term int
 	VoteFor int
 	Responses chan bool
+	LastLogIndex int
+	LastLogTerm int
 }
 
 const UndefinedIndex = -1

--- a/election.go
+++ b/election.go
@@ -40,10 +40,11 @@ func elect(
 	 */
 	case voteRequest := <-(*voteChannels)[state.ServerId]: //implements F1.
 		serverStateLock.Lock()
-		if voteRequest.Term > state.CurrentTerm { // I haven't voted yet (noted by stale term)
-			state.CurrentTerm = voteRequest.Term
-			state.VotedFor = voteRequest.VoteFor
-			serverStateLock.Unlock()
+		lastLogIndex := len(state.Log)
+		lastLogTerm := state.Log[lastLogIndex-1].Term
+		if voteRequest.Term > state.CurrentTerm && //implements RV2.
+			voteRequest.LastLogIndex == len(state.Log) &&
+			voteRequest.LastLogTerm == lastLogTerm{
 			voteRequest.Responses <- true
 		} else { //implements RV1.
 			voteRequest.Responses <- false
@@ -55,9 +56,11 @@ func requestVotes(state *ServerState, voteChannels *[ClusterSize]chan Vote, onWi
 	// send vote requests to other servers
 	//TODO: What if one of the servers is down -- then this will hang forever
 	responses := make(chan bool)
+	candidateLastLogIndex := len(state.Log)
+	candidateLastLogTerm := state.Log[candidateLastLogIndex-1].Term
 	for i, c := range *voteChannels {
 		if i != state.ServerId {
-			c <- Vote{state.CurrentTerm, state.ServerId, responses}
+			c <- Vote{state.CurrentTerm, state.ServerId, responses, candidateLastLogIndex, candidateLastLogTerm}
 		}
 	}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ RPC Requirements:
 
     Request Vote (RV):
         (DONE) RV1. Reply false if term < currentTerm
-        RV2. if votedFor is null or candidateId, and candidates log is at least as up-to-date as receiver's log, grant vote
+        (DONE) RV2. if votedFor is null or candidateId, and candidates log is at least as up-to-date as receiver's log, grant vote
             ! Missing check is candidates log is at least as up-to-date
 
 Requirements for Servers :

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ RPC Requirements:
     Request Vote (RV):
         (DONE) RV1. Reply false if term < currentTerm
         (DONE) RV2. if votedFor is null or candidateId, and candidates log is at least as up-to-date as receiver's log, grant vote
-            ! Missing check is candidates log is at least as up-to-date
 
 Requirements for Servers :
 


### PR DESCRIPTION
if votedFor is null or candidateId, and candidates log is at least as up-to-date as receiver's log, grant vote.

Was missing check for up-to-date log. Did not know exactly how to assure the logs are up-to-date other than compare the term and index of the last logs of both the candidate and the receiver. Leave any comments if you think there is a better way of doing things.