### PR TITLE
C1 - Elections restart on new term if current last election ended with no winner

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -127,7 +127,7 @@ func startLeaderListener(
 				}
 				
 				printMessageFromLeader(state.ServerId, appendEntryRequest)
-				if state.Role != LeaderRole && len(appendEntryRequest.Entries) != 0 {
+				if state.Role != LeaderRole && len(appendEntryRequest.Entries) != 0 { //implements C3.
 					processAppendEntryRequest(appendEntryRequest, state, appendEntriesCom)
 					fmt.Println("Server ", state.ServerId, "'s current log: ", state.Log)
 				}

--- a/cluster.go
+++ b/cluster.go
@@ -127,7 +127,7 @@ func startLeaderListener(
 				}
 				
 				printMessageFromLeader(state.ServerId, appendEntryRequest)
-				if state.Role != LeaderRole && len(appendEntryRequest.Entries) != 0 { //implements C3.
+				if state.Role != LeaderRole && len(appendEntryRequest.Entries) != 0 {
 					processAppendEntryRequest(appendEntryRequest, state, appendEntriesCom)
 					fmt.Println("Server ", state.ServerId, "'s current log: ", state.Log)
 				}

--- a/election.go
+++ b/election.go
@@ -34,7 +34,7 @@ func elect(
 
 		time.Sleep(time.Duration(timeUntilElectionStart) * time.Millisecond) //reset election timer
 
-		//continue elections until you win or turn into a follower
+		//continue elections until you win or turn into a follower when leader sends heartbeats
 		for state.Role == CandidateRole {
 			serverStateLock.Lock()
 			state.CurrentTerm++

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,8 +27,7 @@ Requirements for Servers :
         C1. On conversion to candidate, start election. Includes: increment current term, vote for self, reset election timer, send RequestVote RPC to all other servers
             ! Missing resetting election timer
         (DONE) C2. If votes received from majority of serves: become leader
-        C3. If AppendEntries RPC received from new leader: convert to follower
-            ! Missing check if RPC from leader to leader.
+        (DONE) C3. If AppendEntries RPC received from new leader: convert to follower
         (DONE) C4. If election timeout elapses: start new election
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,7 @@ Requirements for Servers :
         (DONE) F2. If election timeout elapses without receiving AppendEntries from current leader or granting vote to candidate: convert to candidate
 
     Candidates (C):
-        C1. On conversion to candidate, start election. Includes: increment current term, vote for self, reset election timer, send RequestVote RPC to all other servers
-            ! Missing resetting election timer
+        (DONE) C1. On conversion to candidate, start election. Includes: increment current term, vote for self, reset election timer, send RequestVote RPC to all other servers
         (DONE) C2. If votes received from majority of serves: become leader
         (DONE) C3. If AppendEntries RPC received from new leader: convert to follower
         (DONE) C4. If election timeout elapses: start new election


### PR DESCRIPTION
C1. On conversion to candidate, start election. Includes: increment current term, vote for self, reset election timer, send RequestVote RPC to all other servers

Was missing resetting the election timer in case of a tie new elections continue to take place.